### PR TITLE
Feature: Publish to crates.io

### DIFF
--- a/.changelogrc
+++ b/.changelogrc
@@ -1,5 +1,5 @@
 {
-  "name": "changelog-cli",
+  "name": "changelog-rust",
   "extra_commit_args": [],
   "sections": [
     "Feature",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
   release:
     needs: [build_release, setup]
     env:
-      LINUX_EXE: artifacts/x86_64-unknown-linux-musl/changelog-cli
+      LINUX_EXE: artifacts/x86_64-unknown-linux-musl/changelog-rust
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -103,7 +103,7 @@ jobs:
           shopt -s globstar
           shopt -s extglob
           cd artifacts/
-          for input in $(ls -d -- **/changelog-cli?(.*)); do
+          for input in $(ls -d -- **/changelog-rust?(.*)); do
           chmod +x $input
           zip -j "$(basename $(dirname $input)).zip" $input
           done
@@ -157,9 +157,14 @@ jobs:
           access-token: ${{ secrets.CI_PUSH_TOKEN }}
           enforce_admins: true
           branch: ${{ github.ref }}
-      - name: Create Release
-        id: create_release
+      - name: Create Github Release
+        id: create_release_github
         env:
           GITHUB_TOKEN: ${{ secrets.CI_PUSH_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
           gh release create v${{ needs.setup.outputs.VERSION }} -t v${{ needs.setup.outputs.VERSION }} -F CHANGELOG.md ./artifacts/*.zip --target $(git rev-parse HEAD | xargs)
+      - uses: katyo/publish-crates@v1
+        name: Create Crates.io Release
+        id: create_release_crates_io
+        with:
+          registry-token: ${{ secrets.CRATES_IO_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "changelog-cli"
+name = "changelog-rust"
 version = "1.0.15"
 dependencies = [
  "cargo-husky",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,16 @@
 [package]
-name = "changelog-cli"
+name = "changelog-rust"
 version = "1.0.15"
 authors = ["Adam Bratin <adam.bratin@gmail.com>"]
 edition = "2018"
+license = "MIT"
+license-file = "./LICENSE"
+description = "A tool to generate release changelogs"
+readme = "README.md"
+homepage = "https://github.com/adam-bratin/changelog-rs"
+repository = "https://github.com/adam-bratin/changelog-rs"
+keywords = ["cli", "changelog"]
+categories = ["command-line-utilities"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Changelog-Cli
+# Changelog-Rust
 
 This tool is written in rust to be light weight and portable cli for the management and generation of chagelogs for software realease. The idea is to create a way for developers to maintain an up to date changelog with minimal overhead and great integration into CI/CD (agnostic tool that can be used in any CI/CD solution). The idea is for developers to create change files for every story/issue/task/bug/feature (depending of planning tooling the name differs). This prevents uglier solutions of messy git conflict when all developers change a single changelog file. Allows for nice auto generation of changelog file based on predefined template
 
@@ -14,7 +14,7 @@ Download correct version of OS.
 changelog
 
 USAGE:
-    changelog-cli [OPTIONS] <SUBCOMMAND>
+    changelog-rust [OPTIONS] <SUBCOMMAND>
 
 FLAGS:
     -h, --help       Prints help information
@@ -40,7 +40,7 @@ The init command is used to setup a repo to use the cli tool
 
 ```bash
 USAGE:
-    changelog-cli init [OPTIONS] --appName <app-name>
+    changelog-rust init [OPTIONS] --appName <app-name>
 
 FLAGS:
     -h, --help       Prints help information
@@ -62,7 +62,7 @@ It is possible to create a change file non interactive by passing the -t and -d 
 
 ```bash
 USAGE:
-    changelog-cli generate [OPTIONS]
+    changelog-rust generate [OPTIONS]
 
 FLAGS:
     -h, --help       Prints help information
@@ -80,7 +80,7 @@ The merge command is uesed to generate a changelog by parsing all the change fil
 
 ```bash
 USAGE:
-    changelog-cli merge [FLAGS] [OPTIONS]
+    changelog-rust merge [FLAGS] [OPTIONS]
 
 FLAGS:
     -d, --delete     whether to delete change files after changelog is created
@@ -111,7 +111,7 @@ schema:
 
 ```js
 {
-  "name": "changelog-cli", // this is the name of your application
+  "name": "changelog-rust", // this is the name of your application
   "extra_commit_args": ["--no-verify"], // this is optional if you need to skip git hooks
   "sections": [] // this is the list of change types that is used to generate sections in changelog
 }
@@ -154,7 +154,7 @@ the data accessible to the template is: (This is based on default from init comm
   "date": "05/03/2021", // date string in this format
   "versionNoV": "1.0.0", // the version string passed in without a v at front
   "version": "v1.0.0", // version string passed in with v at front
-  "name": "changelog-cli", // application name from .changelogrc
+  "name": "changelog-rust", // application name from .changelogrc
   // There is an entry for each Section from the .changelogrc
   "Feature": [
       {
@@ -175,7 +175,7 @@ any property on the change file based on handle bars syntax as shown in example 
 The output with the above template and data is:
 
 ```markdown
-# Release Notes changelog-cli Version 1.0.0
+# Release Notes changelog-rust Version 1.0.0
 
 05/03/2021
 


### PR DESCRIPTION
- closes #16 Publish to crates.io
- rename to changelog-rust (to match open name on crates.io)
- add step to publish to crates.io